### PR TITLE
Correct docmentation error

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/StageStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/StageStep/help.html
@@ -2,5 +2,5 @@
     By default, Pipeline builds can run concurrently. 
     The stage command lets you mark certain sections of a build as being constrained by limited concurrency.
     Newer builds are always given priority when entering such a throttled stage; older builds will simply exit early if 
-    they are preëmpted.
+    they are preempted.
 </div>


### PR DESCRIPTION
This looks like an error; "preempted" doesn't appear to have a diacritic "e".