### PR TITLE
Prevent `stage` from appearing inside `parallel`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>1.15</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stage/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stage/Messages.properties
@@ -1,0 +1,1 @@
+StageStepExecution.the_stage_step_must_not_be_used_inside_a=The \u2018stage\u2019 step must not be used inside a \u2018parallel\u2019 block.


### PR DESCRIPTION
Tired of diagnosing issues from people who are expecting it would work. It will not, and cannot. Typically they are looking for [JENKINS-26107](https://issues.jenkins-ci.org/browse/JENKINS-26107).

Follows the idea from https://github.com/jenkinsci/pipeline-milestone-step-plugin/pull/1, but pending something like https://github.com/jenkinsci/workflow-api-plugin/pull/2, does it by hand.

@reviewbybees