### PR TITLE
PCT failures: update the workflow plugins in test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin(jenkinsVersions: [null, '2.32.2'])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.13</version>
+        <version>2.21</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>1.15</version>
+            <version>2.12</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -74,13 +74,19 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>1.15</version>
+            <version>2.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>1.15</version>
+            <version>2.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.8</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
With the new changes to the plugin compatibility tester, a few of this plugin's test fail, specifically `StageStepTest`. Currently, it depends on the 1.x line of workflow/pipeline plugins for testing. Since there were significant changes with these plugins upon the 2.x release & the plugin compat tester tests compatibility against the most recent or bundled version of the plugin, the tests are failing even though there are really no issues. This upgrade fixes the 2.x issue and keeps the tests clean for the future.

Also pull in `workflow-durable-task-step` since the necessary steps, in this case `node`, were moved from `workflow-support`.

@reviewbybees