### PR TITLE
Ensure that we are using a consistent version of the workflow-support dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.36</version>
+        <version>3.2</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>
@@ -12,7 +12,7 @@
     <version>2.4-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Stage Step</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Stage+Step+Plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Stage+Step+Plugin</url>
     <licenses>
         <license>
             <name>MIT License</name>
@@ -39,7 +39,9 @@
     </pluginRepositories>
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
+        <java.level>7</java.level>
         <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
+        <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
     </properties>
     <dependencies>
         <dependency>
@@ -72,7 +74,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.14</version>
+            <version>${workflow-support-plugin.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>${workflow-support-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Otherwise under some conditions PCT can get confused:

```
java.lang.Error: Plugin workflow-job failed to start
	at org.jvnet.hudson.test.PluginAutomaticTestBuilder$OtherTests.testPluginActive(PluginAutomaticTestBuilder.java:99)
	at …
Caused by: java.io.IOException: Pipeline: Job v2.16 failed to load.
 - Pipeline: Supporting APIs v2.14 is older than required. To fix, install v2.16 or later.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:626)
	at …
```

@reviewbybees