### PR TITLE
add label and stage actions to block nodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.11</version>
+            <version>2.11.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/StageStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/StageStepExecution.java
@@ -62,6 +62,8 @@ public class StageStepExecution extends AbstractStepExecutionImpl {
 
     @Override
     public boolean start() throws Exception {
+        node.addAction(new LabelAction(step.name));
+        node.addAction(new StageActionImpl(step.name));
         if (getContext().hasBody()) { // recommended mode
             if (step.concurrency != null) {
                 throw new AbortException(Messages.StageStepExecution_concurrency_not_supported_in_block_mode());
@@ -81,8 +83,6 @@ public class StageStepExecution extends AbstractStepExecutionImpl {
         if (isInsideParallel(node)) {
             throw new AbortException(Messages.StageStepExecution_the_stage_step_must_not_be_used_inside_a());
         }
-        node.addAction(new LabelAction(step.name));
-        node.addAction(new StageActionImpl(step.name));
         enter(run, getContext(), step.name, step.concurrency);
         return false; // execute asynchronously
     }


### PR DESCRIPTION
this allows consumers of FlowNodes to determine the stage a nodes belongs to be
search through enclosing nodes with these actions.

Currently the actions are only attached to the (deprecated) no-body version of steps.
I think it should apply to both forms.

`StageAction` is documented as follows (emphasis mine)
```
Attached to a {@link FlowNode} to indicate that it entered a “stage” of a build.
This could be used by high-level visualizations which do not care about individual nodes.
Flow nodes preceding one with this action are considered to be in no stage, or an anonymous stage.
This flow node, and *any descendants* until the next node with this action, are in the stage named here.
```
As the documentation of `StageAction` talks about descendants of nodes with this action, but atoms don't have any descendants it should probably also apply to block nodes.

Also the documentation warns from using the `STAGE_NAME` environment variable from determining the current stage (#13) but does not propose a different way.
The only alternative would be to look at the descriptor of the `StepNode` and compare it to `StageStepNode`. This however would force users to depend on `pipeline-stage-step-plugin`.

The bump of the workflow-job dependency is needed for the `FlowExecutionListener` used in the unit tests.