### PR TITLE
Does not make sense to specify jenkinsVersions older than jenkins.version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.32.3'])
+buildPlugin()


### PR DESCRIPTION
Amendment to #18.